### PR TITLE
Now Diagram class can accept shared_data and Diagram is importable

### DIFF
--- a/bgp_simulator_pkg/__init__.py
+++ b/bgp_simulator_pkg/__init__.py
@@ -11,6 +11,7 @@ from .simulation_engine import RealROVSimpleAS
 from .simulation_engine import SimulationEngine
 from .simulation_engine import Announcement
 
+from .tests import Diagram
 from .tests import DiagramAggregator
 from .tests import EngineTester
 from .tests import EngineTestConfig
@@ -156,6 +157,7 @@ __all__ = ["BGPAS",
            "VictimSuccessSubgraph",
            "VictimSuccessAllSubgraph",
            "Subgraph",
+           "Diagram",
            "DiagramAggregator",
            "EngineTester",
            "EngineTestConfig",

--- a/bgp_simulator_pkg/tests/__init__.py
+++ b/bgp_simulator_pkg/tests/__init__.py
@@ -1,5 +1,6 @@
 from .conftest import pytest_addoption
 
+from .engine_tests import Diagram
 from .engine_tests import DiagramAggregator
 from .engine_tests import TestEngine
 from .engine_tests import EngineTester
@@ -94,6 +95,7 @@ from .engine_tests import Config034
 
 
 __all__ = [
+    "Diagram",
     "DiagramAggregator",
     "pytest_addoption",
     "EngineTester",

--- a/bgp_simulator_pkg/tests/engine_tests/__init__.py
+++ b/bgp_simulator_pkg/tests/engine_tests/__init__.py
@@ -1,4 +1,5 @@
 from .test_engine import TestEngine
+from .utils import Diagram
 from .utils import DiagramAggregator
 from .utils import EngineTestConfig
 from .utils import EngineTester
@@ -95,6 +96,7 @@ from .graphs import Graph050
 from .graphs import Graph051
 
 __all__ = [
+    "Diagram",
     "DiagramAggregator",
     "EngineTestConfig",
     "EngineTester",

--- a/bgp_simulator_pkg/tests/engine_tests/utils/__init__.py
+++ b/bgp_simulator_pkg/tests/engine_tests/utils/__init__.py
@@ -1,10 +1,12 @@
+from .diagram import Diagram
 from .diagram_aggregator import DiagramAggregator
 from .engine_test_config import EngineTestConfig
 # mypy explodes on this line for some reason
 from .engine_tester import EngineTester  # type: ignore
 from .simulator_codec import SimulatorCodec
 
-__all__ = ["DiagramAggregator",
+__all__ = ["Diagram",
+           "DiagramAggregator",
            "EngineTestConfig",
            "EngineTester",
            "SimulatorCodec"]

--- a/bgp_simulator_pkg/tests/engine_tests/utils/diagram.py
+++ b/bgp_simulator_pkg/tests/engine_tests/utils/diagram.py
@@ -17,6 +17,7 @@ class Diagram:
                           scenario,
                           traceback,
                           description,
+                          shared_data,
                           path=None,
                           view=False):
         self._add_legend(traceback)

--- a/bgp_simulator_pkg/tests/engine_tests/utils/engine_tester.py
+++ b/bgp_simulator_pkg/tests/engine_tests/utils/engine_tester.py
@@ -72,7 +72,7 @@ class EngineTester:
         # Store engine and traceback YAML
         self._store_yaml(engine, outcomes_yaml, shared_data)
         # Create diagrams before the test can fail
-        self._generate_diagrams()
+        self._generate_diagrams(shared_data)
         # Compare the YAML's together
         self._compare_yaml()
 
@@ -112,7 +112,7 @@ class EngineTester:
             self.codec.dump(shared_data,
                             path=self.shared_data_ground_truth_path)
 
-    def _generate_diagrams(self):
+    def _generate_diagrams(self, shared_data):
         """Generates diagrams"""
 
         # Load engines
@@ -127,7 +127,8 @@ class EngineTester:
             engine_guess,
             self.conf.scenario,  # type: ignore
             outcomes_guess,
-            f"({self.conf.name} Guess)\n{self.conf.desc}",  # type: ignore
+            f"({self.conf.name} Guess)\n{self.conf.desc}",  # type: ignore,
+            shared_data,
             path=self.test_dir / "guess.gv",
             view=False)
         # Write ground truth graph
@@ -136,7 +137,8 @@ class EngineTester:
             self.conf.scenario,  # type: ignore
             outcomes_gt,
             f"({self.conf.name} Ground Truth)\n"  # type: ignore
-            f"{self.conf.desc}",  # type: ignore
+            f"{self.conf.desc}",  # type: ignore,
+            shared_data,
             path=self.test_dir / "ground_truth.gv",
             view=False)
 


### PR DESCRIPTION
This feature allows the Diagram class to be given shared_data to visualize as needed. Also allows others to import Diagram for subclassing for custom diagrams.

I rebased it onto lastest from master, so it should be easy to merge.