### PR TITLE
Initialize subgraphs on simulation object initialization

### DIFF
--- a/bgp_simulator_pkg/simulation_framework/simulation.py
+++ b/bgp_simulator_pkg/simulation_framework/simulation.py
@@ -44,9 +44,9 @@ class Simulation:
         """
 
         if subgraphs is None:
-            subgraphs = tuple([
+            subgraphs = tuple([ # type: ignore
                 Cls() for Cls in  # type: ignore
-                Subgraph.subclasses if Cls.name])
+                Subgraph.subclasses if Cls.name]) # type: ignore
         self.percent_adoptions: Tuple[Union[float,
                                             SpecialPercentAdoptions],
                                       ...] = percent_adoptions

--- a/bgp_simulator_pkg/simulation_framework/simulation.py
+++ b/bgp_simulator_pkg/simulation_framework/simulation.py
@@ -44,9 +44,9 @@ class Simulation:
         """
 
         if subgraphs is None:
-            subgraphs = tuple([ # type: ignore
+            subgraphs = tuple([  # type: ignore
                 Cls() for Cls in  # type: ignore
-                Subgraph.subclasses if Cls.name]) # type: ignore
+                Subgraph.subclasses if Cls.name])  # type: ignore
         self.percent_adoptions: Tuple[Union[float,
                                             SpecialPercentAdoptions],
                                       ...] = percent_adoptions

--- a/bgp_simulator_pkg/simulation_framework/simulation.py
+++ b/bgp_simulator_pkg/simulation_framework/simulation.py
@@ -30,9 +30,7 @@ class Simulation:
                     [SubprefixHijack(AdoptASCls=x)  # type: ignore
                      for x in [ROVSimpleAS]]
                     ),
-                 subgraphs: Tuple[Subgraph, ...] = tuple([
-                    Cls() for Cls in  # type: ignore
-                    Subgraph.subclasses if Cls.name]),  # type: ignore
+                 subgraphs: Tuple[Subgraph, ...] = None,  # type: ignore
                  num_trials: int = 2,
                  propagation_rounds: int = 1,
                  output_path: Path = Path("/tmp/graphs"),
@@ -45,6 +43,10 @@ class Simulation:
         mp_method: Multiprocessing method
         """
 
+        if subgraphs is None:
+            subgraphs = tuple([
+                Cls() for Cls in  # type: ignore
+                Subgraph.subclasses if Cls.name])
         self.percent_adoptions: Tuple[Union[float,
                                             SpecialPercentAdoptions],
                                       ...] = percent_adoptions


### PR DESCRIPTION
If the subgraphs are initialized in the default parameters for the Simulation object's `__init__` method they are initialized once at the class definition and never again. With the new framework sim input tests, multiple simulations are run without exiting the process. When this happens, old data from previous simulations is carried over and this eventually uses all of the memory on the machine. 

This fix moves the initialization of the subgraph objects out of the default parameter so that the data is correctly cleared between sim input test runs. 