### PR TITLE
Fix prev scenario not being set correctly

### DIFF
--- a/bgp_simulator_pkg/simulation_framework/simulation.py
+++ b/bgp_simulator_pkg/simulation_framework/simulation.py
@@ -222,6 +222,7 @@ class Simulation:
 
                     # By default, this is a no op
                     scenario.post_propagation_hook(**kwargs)
+                prev_scenario = scenario
             # Reset scenario for next round of trials
             prev_scenario = None
         return subgraphs


### PR DESCRIPTION
The prev_scenario variable needs to be set for each trial to use the same attacker/victim pair and set of adopting ASes between each scenario. Before this change, it was only always set to None. 