### PR TITLE
Fix default non adopters sometimes adopting

### DIFF
--- a/bgp_simulator_pkg/simulation_framework/scenarios/scenario.py
+++ b/bgp_simulator_pkg/simulation_framework/scenarios/scenario.py
@@ -393,6 +393,10 @@ class Scenario(ABC):
             engine,
             percent_adoption,
             prev_scenario=prev_scenario)
+        # If any of the default non adopting ASes were added, remove them
+        for asn in self._default_non_adopters:
+            if asn in self.non_default_as_cls_dict:
+                del self.non_default_as_cls_dict[asn]
         # Validate that this is only non_default ASes
         # This matters, because later this entire dict may be used for the next
         # scenario


### PR DESCRIPTION
Without this check, it is possible for the default non-adopters to be included in the non_default_as_cls_dict, making them adopters in the simulation.